### PR TITLE
Clear the Nodes after commit

### DIFF
--- a/client.go
+++ b/client.go
@@ -167,6 +167,10 @@ func (g *Graph) Commit() (QueryResult, error) {
 		q += fmt.Sprintf("%s,", e)
 	}
 	q = q[:len(q)-1]
+
+	//We need to zero all of the commands when committing or they will accumulate
+	g.Nodes = make(map[string]*Node)
+
 	return g.Query(q)
 }
 


### PR DESCRIPTION
Running the following 

```
package main

import (
        "fmt"
        "github.com/gomodule/redigo/redis"
        rg "github.com/redislabs/redisgraph-go"
)

func main() {
        conn, _ := redis.Dial("tcp", "localhost:6379")
        defer conn.Close()

        graph := rg.Graph{}.New("social", conn)

        users := [3]string{"Barney", "Betty", "Bam-Bam"}

        for k, user := range users {

                family := rg.Node{
                        Label: "person",
                        Properties: map[string]interface{}{
                                "name": fmt.Sprintf("%s Rubble", user),
                                "age":  66 / (k + 2),
                        },
                }
                graph.AddNode(&family)
                graph.Commit()
        }

        query := "MATCH (p:person) RETURN p.name"
        rs, _ := graph.Query(query)

        rs.PrettyPrint()
}
```
Returns:

```
+----------------+
|     p.name     |
+----------------+
| Barney Rubble  |
| Barney Rubble  |
| Betty Rubble   |
| Barney Rubble  |
| Betty Rubble   |
| Bam-Bam Rubble |
+----------------+
```

Running Monitor seems to show that the node map is not being cleared after commiit

```
1542758947.998021 [0 127.0.0.1:61749] "GRAPH.QUERY" "social" "CREATE (BbUuWmSqQS:person{name:\"Barney Rubble\",age:33})"
1542758947.998647 [0 127.0.0.1:61749] "GRAPH.QUERY" "social" "CREATE (BbUuWmSqQS:person{name:\"Barney Rubble\",age:33}),(TfTgQICgTE:person{name:\"Betty Rubble\",age:22})"
1542758947.999356 [0 127.0.0.1:61749] "GRAPH.QUERY" "social" "CREATE (BbUuWmSqQS:person{name:\"Barney Rubble\",age:33}),(TfTgQICgTE:person{name:\"Betty Rubble\",age:22}),(nrTQwhTlDQ:person{name:\"Bam-Bam Rubble\",age:16})"
1542758947.999977 [0 127.0.0.1:61749] "GRAPH.QUERY" "social" "MATCH (p:person) RETURN p.name"
```